### PR TITLE
Select raw and call

### DIFF
--- a/datamapper/__init__.py
+++ b/datamapper/__init__.py
@@ -1,6 +1,7 @@
 import datamapper.errors as errors
+from datamapper.changeset import Changeset
 from datamapper.model import Associations, BelongsTo, HasMany, HasOne, Model
-from datamapper.query import Query
+from datamapper.query import Query, call, raw
 from datamapper.repo import Repo
 
 __version__ = "0.1.0"
@@ -8,10 +9,13 @@ __version__ = "0.1.0"
 __all__ = [
     "Associations",
     "BelongsTo",
+    "Changeset",
     "HasMany",
     "HasOne",
     "Model",
     "Query",
     "Repo",
+    "call",
     "errors",
+    "raw",
 ]

--- a/datamapper/errors.py
+++ b/datamapper/errors.py
@@ -6,16 +6,18 @@ if TYPE_CHECKING:
     from datamapper.changeset import Changeset  # pragma: no cover
 
 __all__ = [
-    "Error",
-    "UnknownColumnError",
-    "UnknownAssociationError",
-    "UnknownAliasError",
-    "NoResultsError",
-    "MultipleResultsError",
-    "NotLoadedError",
-    "MultipleResultsError",
-    "MissingJoinError",
     "ConflictingAliasError",
+    "Error",
+    "InvalidExpressionError",
+    "InvalidSelectError",
+    "MissingJoinError",
+    "MultipleResultsError",
+    "MultipleResultsError",
+    "NoResultsError",
+    "NotLoadedError",
+    "UnknownAliasError",
+    "UnknownAssociationError",
+    "UnknownColumnError",
 ]
 
 
@@ -66,6 +68,11 @@ class ConflictingAliasError(Error):
 class InvalidExpressionError(Error):
     def __init__(self, value: Any):
         super().__init__(f"`{type(value).__name__}` is not a valid query expression")
+
+
+class InvalidSelectError(Error):
+    def __init__(self) -> None:
+        super().__init__("expected at least one select expression but got none")
 
 
 class InvalidChangesetError(Error):

--- a/datamapper/query/__init__.py
+++ b/datamapper/query/__init__.py
@@ -1,3 +1,3 @@
-from .query import Query
+from .query import Query, call, raw
 
-__all__ = ["Query"]
+__all__ = ["Query", "raw", "call"]

--- a/datamapper/query/query.py
+++ b/datamapper/query/query.py
@@ -428,11 +428,43 @@ def _build_result(select: SelectClause, values: list) -> Any:
 
 
 class raw:
+    """
+    Used to return a literal value from a query without ever sending it to the
+    database.
+
+    Once executed, the query in the example below will return `{"old": True}`
+    for each row returned from the database.
+
+    Example::
+
+        Query(User).where(age__gt=100).select(raw({"old": True}))
+        SELECT 1 FROM users WHERE users.age > 100
+    """
+
     def __init__(self, value: Any):
         self.value = value
 
 
 class call:
+    """
+    Used to customize how results are deserialized when they are returned from
+    the database.
+
+    Once executed, the query in the example below will call `is_old` with the
+    age of each user in the resulting query
+
+    In the example below, `is_old` will be called with the age of each user.
+    The result of executing this query will be a list of boolean values.
+
+    Example::
+
+        def is_old(age):
+            return age > 100
+
+        Query(User).select(call(is_old, "age"))
+        # SELECT users.age FROM users
+    """
+
     def __init__(self, func: Callable, *args: SelectClause, **kwargs: SelectClause):
         self.func = func
         self.args = args

--- a/datamapper/query/query.py
+++ b/datamapper/query/query.py
@@ -7,7 +7,7 @@ from sqlalchemy.sql.expression import ClauseElement, Delete, FromClause, Select,
 
 import datamapper.model as model
 from datamapper._utils import get_column
-from datamapper.errors import InvalidExpressionError
+from datamapper.errors import InvalidExpressionError, InvalidSelectError
 from datamapper.query.alias_tracker import AliasTracker
 from datamapper.query.join import Join, to_join_tree
 from datamapper.query.parser import parse_column, parse_order, parse_where
@@ -330,6 +330,10 @@ class Query:
 
     def __build_select(self, sql: Statement, tracker: AliasTracker) -> Statement:
         clauses = self.__reduce_select([], self._select, tracker)
+
+        if len(clauses) == 0:
+            raise InvalidSelectError()
+
         return sql.with_only_columns(clauses)
 
     def __reduce_select(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -281,6 +281,11 @@ def test_select_raw():
     assert "SELECT 1" in to_sql(query.to_sql())
 
 
+def test_select_call():
+    query = Query(User).select(call(lambda x: x, "id"))
+    assert "SELECT users.id" in to_sql(query.to_sql())
+
+
 def test_select_empty():
     query = Query(User)
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -3,7 +3,11 @@ from sqlalchemy import text
 from sqlalchemy.sql.expression import Select
 
 from datamapper import Query, call, raw
-from datamapper.errors import InvalidExpressionError, MissingJoinError
+from datamapper.errors import (
+    InvalidExpressionError,
+    InvalidSelectError,
+    MissingJoinError,
+)
 from tests.support import User, to_sql
 
 
@@ -275,6 +279,17 @@ def test_select_nested():
 def test_select_raw():
     query = Query(User).select(raw(100))
     assert "SELECT 1" in to_sql(query.to_sql())
+
+
+def test_select_empty():
+    query = Query(User)
+
+    with pytest.raises(InvalidSelectError):
+        query.select([]).to_sql()
+    with pytest.raises(InvalidSelectError):
+        query.select(()).to_sql()
+    with pytest.raises(InvalidSelectError):
+        query.select({}).to_sql()
 
 
 def test_select_invalid():

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,7 +2,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.sql.expression import Select
 
-from datamapper import Query
+from datamapper import Query, call, raw
 from datamapper.errors import InvalidExpressionError, MissingJoinError
 from tests.support import User, to_sql
 
@@ -272,8 +272,13 @@ def test_select_nested():
     assert "SELECT users.id, p.id" in to_sql(query.to_sql())
 
 
+def test_select_raw():
+    query = Query(User).select(raw(100))
+    assert "SELECT 1" in to_sql(query.to_sql())
+
+
 def test_select_invalid():
-    query = Query(User).select(1)
+    query = Query(User).select(100)
     message = "`int` is not a valid query expression"
 
     with pytest.raises(InvalidExpressionError, match=message):

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -365,14 +365,14 @@ async def test_select_nested(repo):
 
 @pytest.mark.asyncio
 async def test_select_raw(repo):
-    await repo.insert(User)
+    await repo.insert(User())
     query = Query(User).select(raw(100))
     assert await repo.one(query) == 100
 
 
 @pytest.mark.asyncio
 async def test_select_call(repo):
-    user = await repo.insert(User, name="Fred")
+    user = await repo.insert(User(name="Fred"))
     query = Query(User).select(call(handle_call, "id", raw(100), name="name"))
     assert await repo.one(query) == ((user.id, 100), {"name": user.name})
 


### PR DESCRIPTION
`raw` can be used to tell datamapper to return a raw value. It makes no attempt to retrieve the value from the query result.

```python
>>> await repo.one(Query(User).select({"name": raw("name")}))
# SELECT 1 FROM users
{"name": "name"}
```

`call` can be used to provide custom deserialization logic.

```python
class Foo:
    def __init__(self, id, name):
        self.id = id
        self.name = name

>>> await repo.one(Query(User).select(call(Foo, "id", name="name")))
# SELECT users.id, users.name FROM users
<Foo id=1 name="name">
```