### PR TITLE
Changeset enhancements

### DIFF
--- a/datamapper/changeset.py
+++ b/datamapper/changeset.py
@@ -50,8 +50,14 @@ class ChangesetDataWrapper(Generic[T]):
         return self.data.association(field)
 
     @property
-    def type(self) -> Type:
-        return type(self.data)  # pragma: no cover
+    def attributes(self) -> dict:
+        if isinstance(self.data, dict):
+            return self.data
+        else:
+            return self.data.attributes
+
+    def __repr__(self) -> str:
+        return type(self.data).__name__
 
 
 def dict_merge(dct: dict, merge_dct: dict) -> dict:
@@ -232,7 +238,15 @@ class Changeset(Generic[T]):
             return result
 
     def __repr__(self) -> str:
-        return f"<Changeset data={self._wrapped_data.type}>"  # pragma: no cover
+        return (
+            f"<Changeset\n"
+            f" is_valid={self.is_valid}\n"
+            f" data={self._wrapped_data}{self._wrapped_data.attributes}\n"
+            f" params={self.params}\n"
+            f" changes={self.changes}\n"
+            f" errors={self.errors}"
+            ">"
+        )  # pragma: no cover
 
     def _update(self, **kwargs: Any) -> Changeset:
         # Can replace this with an immutable collection library.

--- a/datamapper/changeset.py
+++ b/datamapper/changeset.py
@@ -12,6 +12,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
 )
 
 import sqlalchemy
@@ -263,6 +264,40 @@ class Changeset(Generic[T]):
             return True if value not in vals else msg
 
         self._add_field_validator(field, _validate_exclusion)
+        return self
+
+    def validate_length(
+        self,
+        field: str,
+        length: Optional[int] = None,
+        minimum: Optional[int] = None,
+        maximum: Optional[int] = None,
+        message: Optional[str] = None,
+    ) -> Changeset:
+        if length is not None:
+
+            def _validate_exact_length(val: Any) -> Union[bool, str]:
+                message_ = message or f"should be {length} characters"
+                return True if len(val) == length else message_
+
+            self._add_field_validator(field, _validate_exact_length)
+
+        if minimum is not None:
+
+            def _validate_min_length(val: Any) -> Union[bool, str]:
+                message_ = message or f"should be at least {minimum} characters"
+                return True if len(val) >= cast(int, minimum) else message_
+
+            self._add_field_validator(field, _validate_min_length)
+
+        if maximum is not None:
+
+            def _validate_max_length(val: Any) -> Union[bool, str]:
+                message_ = message or f"should be at most {maximum} characters"
+                return True if len(val) <= cast(int, maximum) else message_
+
+            self._add_field_validator(field, _validate_max_length)
+
         return self
 
     def change(self, changes: dict) -> Changeset:

--- a/datamapper/changeset.py
+++ b/datamapper/changeset.py
@@ -201,7 +201,7 @@ class Changeset(Generic[T]):
 
     def cast(self, params: Mapping[str, Any], permitted: List[str]) -> Changeset:
         """
-        Applies `params` as changes to the changeset, provided that their keys are `permitted`.
+        Applies `params` as changes to the changeset, provided that their keys are in `permitted` and their types are correct.
         """
         permitted_params = {k: v for (k, v) in params.items() if k in permitted}
         return self._update(
@@ -328,6 +328,12 @@ class Changeset(Generic[T]):
             return f(self, changed_value)
         else:
             return self
+
+    def pipe(self, f: Callable[[Changeset], Changeset]) -> Changeset:
+        """
+        Pipe the Changeset into the function f, returning a new Changeset.
+        """
+        return f(self)
 
     def apply_changes(self) -> T:
         """

--- a/datamapper/changeset.py
+++ b/datamapper/changeset.py
@@ -249,18 +249,18 @@ class Changeset(Generic[T]):
         return self
 
     def validate_inclusion(
-        self, field: str, value: Any, msg: str = "is invalid"
+        self, field: str, vals: Any, msg: str = "is invalid"
     ) -> Changeset:
-        def _validate_inclusion(vals: Any) -> Union[bool, str]:
+        def _validate_inclusion(value: Any) -> Union[bool, str]:
             return True if value in vals else msg
 
         self._add_field_validator(field, _validate_inclusion)
         return self
 
     def validate_exclusion(
-        self, field: str, value: Any, msg: str = "is invalid"
+        self, field: str, vals: Any, msg: str = "is invalid"
     ) -> Changeset:
-        def _validate_exclusion(vals: Any) -> Union[bool, str]:
+        def _validate_exclusion(value: Any) -> Union[bool, str]:
             return True if value not in vals else msg
 
         self._add_field_validator(field, _validate_exclusion)

--- a/datamapper/changeset.py
+++ b/datamapper/changeset.py
@@ -174,7 +174,10 @@ class MarshmallowValidator:
             else fields.Raw
         )
 
-        type_args: Dict[str, Any] = {"required": name in self.changeset.required}
+        type_args: Dict[str, Any] = {
+            "allow_none": True,
+            "required": name in self.changeset.required,
+        }
 
         field_validators = self.changeset._field_validators.get(name)
         if field_validators:
@@ -313,6 +316,9 @@ class Changeset(Generic[T]):
         self._forced_changes = dict_merge(self._forced_changes, changes)
         return self
 
+    def has_change(self, field: str) -> bool:
+        return field in self.changes
+
     def put_change(self, field: str, value: Any) -> Changeset:
         """
         Puts a change on the given `field` with `value`.
@@ -329,9 +335,8 @@ class Changeset(Generic[T]):
         If `field` has been changed, call callback function `f` with the value,
         returning a new Changeset.
         """
-        changed_value = self.fetch_change(field)
-        if changed_value is not None:
-            return f(self, changed_value)
+        if self.has_change(field):
+            return f(self, self.fetch_change(field))
         else:
             return self
 

--- a/datamapper/changeset.py
+++ b/datamapper/changeset.py
@@ -225,6 +225,12 @@ class Changeset(Generic[T]):
         """
         return self.changes.get(field)
 
+    def get_change(self, field: str, default: Any = None) -> Optional[Any]:
+        """
+        Gets a change or returns a default value.
+        """
+        return self.changes.get(field, default)
+
     def fetch_field(self, field: str) -> Optional[Any]:
         """
         Fetches a field from `changes` if it exists, falling back to `data`.

--- a/datamapper/changeset.py
+++ b/datamapper/changeset.py
@@ -280,6 +280,20 @@ class Changeset(Generic[T]):
         """
         self._forced_changes[field] = value
         return self
+
+    def on_changed(
+        self, field: str, f: Callable[[Changeset, Any], Changeset]
+    ) -> Changeset:
+        """
+        If `field` has been changed, call callback function `f` with the value,
+        returning a new Changeset.
+        """
+        changed_value = self.fetch_change(field)
+        if changed_value is not None:
+            return f(self, changed_value)
+        else:
+            return self
+
     def apply_changes(self) -> T:
         """
         Apply the changeset's changes to the data.

--- a/datamapper/model.py
+++ b/datamapper/model.py
@@ -97,6 +97,9 @@ class Model:
             f"'{self.__class__.__name__}' object has no attribute '{key}'"
         )
 
+    def __repr__(self) -> str:
+        return f"<{type(self).__name__} {self.attributes}>"  # pragma: no cover
+
 
 class Cardinality(enum.Enum):
     ONE = "one"

--- a/tests/console.py
+++ b/tests/console.py
@@ -5,6 +5,7 @@ from databases import Database
 from IPython import start_ipython
 
 from datamapper import Query, Repo
+from datamapper.changeset import Changeset
 from tests.support import Home, Pet, User, provision_database
 
 logging.basicConfig(level=logging.DEBUG)
@@ -20,6 +21,7 @@ context = {
     "database": database,
     "repo": repo,
     "Query": Query,
+    "Changeset": Changeset,
     "User": User,
     "Pet": Pet,
     "Home": Home,

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -225,6 +225,24 @@ def test_schemaless_apply_changes():
     assert changeset.apply_changes() == {"name": "Gordon", "age": 14, "color": "brown"}
 
 
+def test_on_changed():
+    def _slugify(changeset, title):
+        return changeset.put_change("slug", title.lower().replace(" ", "-"))
+
+    params = {
+        "title": "Crime and Punishment",
+        "publish_date": date(1866, 1, 1),
+    }
+    book = (
+        Changeset(Book())
+        .cast(params, ["title", "publish_date"])
+        .on_changed("title", _slugify)
+        .apply_changes()
+    )
+
+    assert book.slug == "crime-and-punishment"
+
+
 def test_fetch_change_from_changes():
     assert (
         Changeset(Book(title="Crime and Punishment"))
@@ -264,6 +282,7 @@ def test_put_change():
         .put_change("isbn", "01234567890")
         .changes["isbn"]
     ) == "01234567890"
+
 
 def test_invalid_data():
     with pytest.raises(AttributeError):

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -250,6 +250,19 @@ def test_on_changed_with_no_change():
     assert changeset.changes.get("slug") is None
 
 
+def test_on_changed_when_changing_value_to_none():
+    params = {
+        "title": None,
+        "publication_date": date(1866, 1, 1),
+    }
+    changeset = (
+        Changeset(Book(title="Crime and Punishment"))
+        .cast(params, ["title", "publication_date"])
+        .on_changed("title", lambda cs, v: cs.put_change("slug", "slug-removed"))
+    )
+    assert changeset.changes.get("slug") == "slug-removed"
+
+
 def test_fetch_change_from_changes():
     assert (
         Changeset(Book(title="Crime and Punishment"))

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -39,6 +39,7 @@ class Book(Model):
         sa.Column("slug", sa.String(255)),
     )
 
+
 def test_cast_empty():
     changeset = Changeset(User()).cast({}, [])
     assert changeset.is_valid
@@ -241,6 +242,21 @@ def test_on_changed():
     )
 
     assert book.slug == "crime-and-punishment"
+
+
+def test_on_changed_with_no_change():
+    def _slugify(changeset, title):
+        return changeset.put_change("slug", title.lower().replace(" ", "-"))
+
+    params = {
+        "publish_date": date(1866, 1, 1),
+    }
+    changeset = (
+        Changeset(Book(title="Crime and Punishment"))
+        .cast(params, ["title", "publish_date"])
+        .on_changed("title", _slugify)
+    )
+    assert changeset.changes.get("slug") is None
 
 
 def test_fetch_change_from_changes():

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -263,36 +263,58 @@ def test_on_changed_when_changing_value_to_none():
     assert changeset.changes.get("slug") == "slug-removed"
 
 
-def test_fetch_change_from_changes():
+def test_get_change_from_changes():
     assert (
         Changeset(Book(title="Crime and Punishment"))
         .cast({"title": "The Brothers Karamazov"}, ["title"])
-        .fetch_change("title")
+        .get_change("title")
     ) == "The Brothers Karamazov"
 
 
-def test_fetch_change_from_data():
+def test_get_change_not_found():
     assert (
         Changeset(Book(title="Crime and Punishment"))
         .cast({"isbn": "1234567890"}, ["isbn"])
-        .fetch_change("title")
+        .get_change("title")
     ) is None
 
 
-def test_fetch_field_from_changes():
-    assert (
-        Changeset(Book(title="Crime and Punishment"))
-        .cast({"title": "The Brothers Karamazov"}, ["title"])
-        .fetch_field("title")
-    ) == "The Brothers Karamazov"
-
-
-def test_fetch_field_from_data():
+def test_get_change_not_found_with_custom_default():
     assert (
         Changeset(Book(title="Crime and Punishment"))
         .cast({"isbn": "1234567890"}, ["isbn"])
-        .fetch_field("title")
+        .get_change("title", "foo")
+    ) == "foo"
+
+
+def test_get_field_from_changes():
+    assert (
+        Changeset(Book(title="Crime and Punishment"))
+        .cast({"title": "The Brothers Karamazov"}, ["title"])
+        .get_field("title")
+    ) == "The Brothers Karamazov"
+
+
+def test_get_field_from_data():
+    assert (
+        Changeset(Book(title="Crime and Punishment"))
+        .cast({"isbn": "1234567890"}, ["isbn"])
+        .get_field("title")
     ) == "Crime and Punishment"
+
+
+def test_get_field_not_found():
+    assert (
+        Changeset(Book()).cast({"isbn": "1234567890"}, ["isbn"]).get_field("title")
+    ) is None
+
+
+def test_get_field_not_found_custom_default():
+    assert (
+        Changeset(Book())
+        .cast({"isbn": "1234567890"}, ["isbn"])
+        .get_field("title", "foo")
+    ) == "foo"
 
 
 def test_put_change():

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -334,6 +334,14 @@ def test_get_change_not_found_default_value():
 def test_get_change_not_found_custom_value():
     assert (Changeset(Book()).get_change("foo", "baz")) == "baz"
 
+
+def test_pipe():
+    def _put_foo(changeset: Changeset) -> Changeset:
+        return changeset.put_change("foo", "bar")
+
+    assert Changeset(Book()).pipe(_put_foo).changes == {"foo": "bar"}
+
+
 def test_invalid_data():
     with pytest.raises(AttributeError):
         Changeset("foo")

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -87,6 +87,66 @@ def test_validate_change():
     }
 
 
+def test_validate_inclusion_valid():
+    assert (
+        Changeset(Person())
+        .cast(
+            {
+                "name": "Richard",
+                "age": 30,
+                "favorite_animals": ["cat", "bat", "rat", "weasel"],
+            },
+            ["name", "age", "favorite_animals"],
+        )
+        .validate_inclusion("favorite_animals", "weasel")
+    ).is_valid
+
+
+def test_validate_inclusion_invalid():
+    changeset = (
+        Changeset(Person())
+        .cast(
+            {"name": "Richard", "age": 30, "favorite_animals": ["cat", "bat", "rat"]},
+            ["name", "age", "favorite_animals"],
+        )
+        .validate_inclusion("favorite_animals", "ferret", "you love ferrets")
+    )
+
+    assert changeset.errors == {"favorite_animals": ["you love ferrets"]}
+
+
+def test_validate_exclusion_valid():
+    assert (
+        Changeset(Person())
+        .cast(
+            {
+                "name": "Richard",
+                "age": 30,
+                "favorite_animals": ["cat", "bat", "rat", "weasel"],
+            },
+            ["name", "age", "favorite_animals"],
+        )
+        .validate_exclusion("favorite_animals", "spider")
+    ).is_valid
+
+
+def test_validate_exclusion_invalid():
+    changeset = (
+        Changeset(Person())
+        .cast(
+            {
+                "name": "Richard",
+                "age": 30,
+                "favorite_animals": ["cat", "bat", "rat", "spider"],
+            },
+            ["name", "age", "favorite_animals"],
+        )
+        .validate_exclusion("favorite_animals", "spider", "you hate spiders")
+    )
+
+    assert changeset.errors == {"favorite_animals": ["you hate spiders"]}
+
+
 def test_validate_change_only_validates_if_field_is_changed():
     changeset = (
         Changeset(Person())

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -300,6 +300,38 @@ def test_put_change():
     ) == "01234567890"
 
 
+def test_validate_length_exact():
+    assert (
+        Changeset(Book())
+        .cast({"isbn": "123456789"}, ["isbn"])
+        .validate_length("isbn", 10)
+    ).errors["isbn"] == ["should be 10 characters"]
+
+
+def test_validate_length_minimum():
+    assert (
+        Changeset(Book())
+        .cast({"isbn": "123456789"}, ["isbn"])
+        .validate_length("isbn", minimum=10)
+    ).errors["isbn"] == ["should be at least 10 characters"]
+
+
+def test_validate_length_maximum():
+    assert (
+        Changeset(Book())
+        .cast({"isbn": "12345678901234"}, ["isbn"])
+        .validate_length("isbn", maximum=13)
+    ).errors["isbn"] == ["should be at most 13 characters"]
+
+
+def test_validate_length_in_between():
+    assert (
+        Changeset(Book())
+        .cast({"isbn": "123456789"}, ["isbn"])
+        .validate_length("isbn", minimum=9, maximum=9)
+    ).is_valid
+
+
 def test_invalid_data():
     with pytest.raises(AttributeError):
         Changeset("foo")

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -323,6 +323,17 @@ def test_validate_length_in_between():
     ).is_valid
 
 
+def test_get_change_found():
+    assert (Changeset(Book()).put_change("foo", "bar").get_change("foo")) == "bar"
+
+
+def test_get_change_not_found_default_value():
+    assert (Changeset(Book()).get_change("foo")) is None
+
+
+def test_get_change_not_found_custom_value():
+    assert (Changeset(Book()).get_change("foo", "baz")) == "baz"
+
 def test_invalid_data():
     with pytest.raises(AttributeError):
         Changeset("foo")

--- a/tests/test_changesets.py
+++ b/tests/test_changesets.py
@@ -35,7 +35,7 @@ class Book(Model):
         sa.Column("id", sa.Integer, primary_key=True),
         sa.Column("title", sa.String(255)),
         sa.Column("isbn", sa.String(255)),
-        sa.Column("publish_date", sa.Date()),
+        sa.Column("publication_date", sa.Date()),
         sa.Column("slug", sa.String(255)),
     )
 
@@ -232,11 +232,11 @@ def test_on_changed():
 
     params = {
         "title": "Crime and Punishment",
-        "publish_date": date(1866, 1, 1),
+        "publication_date": date(1866, 1, 1),
     }
     book = (
         Changeset(Book())
-        .cast(params, ["title", "publish_date"])
+        .cast(params, ["title", "publication_date"])
         .on_changed("title", _slugify)
         .apply_changes()
     )
@@ -249,11 +249,11 @@ def test_on_changed_with_no_change():
         return changeset.put_change("slug", title.lower().replace(" ", "-"))
 
     params = {
-        "publish_date": date(1866, 1, 1),
+        "publication_date": date(1866, 1, 1),
     }
     changeset = (
         Changeset(Book(title="Crime and Punishment"))
-        .cast(params, ["title", "publish_date"])
+        .cast(params, ["title", "publication_date"])
         .on_changed("title", _slugify)
     )
     assert changeset.changes.get("slug") is None


### PR DESCRIPTION
Adds a bunch of new `Changeset` methods:

* `fetch_change`
* `get_change`
* `has_change`
* `put_change`
* `fetch_field`
* `validate_inclusion`
* `validate_exclusion`
* `validate_length`
* `on_change`
* `pipe`

`changeset.py` is getting huge now, so I've got another branch where I've refactored it into a module. It's ready for PR right after this one.