### PR TITLE
Raise an error for an invalid changeset

### DIFF
--- a/datamapper/errors.py
+++ b/datamapper/errors.py
@@ -1,4 +1,9 @@
-from typing import Any
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from datamapper.changeset import Changeset  # pragma: no cover
 
 __all__ = [
     "Error",
@@ -61,3 +66,13 @@ class ConflictingAliasError(Error):
 class InvalidExpressionError(Error):
     def __init__(self, value: Any):
         super().__init__(f"`{type(value).__name__}` is not a valid query expression")
+
+
+class InvalidChangesetError(Error):
+    def __init__(self, action: str, changeset: Changeset):
+        super().__init__(
+            f"could not perform {action} because changeset is invalid:\n\n{changeset}"
+        )
+
+        self.action = action
+        self.changeset = changeset

--- a/datamapper/repo.py
+++ b/datamapper/repo.py
@@ -117,9 +117,7 @@ class Repo:
         sql = func.count().select().select_from(sql)
         return await self.database.fetch_val(sql)
 
-    async def insert(
-        self, model_or_changeset: Union[Model, Changeset[Model]]
-    ) -> Union[Model, Changeset]:
+    async def insert(self, model_or_changeset: Union[Model, Changeset[Model]]) -> Model:
         """
         Insert a record into the database.
 
@@ -137,7 +135,7 @@ class Repo:
         record_id = await self.database.execute(sql)
         return changeset.change({"id": record_id}).apply_changes()
 
-    async def update(self, changeset: Changeset) -> Union[Model, Changeset]:
+    async def update(self, changeset: Changeset) -> Model:
         """
         Update a record in the database.
 

--- a/datamapper/repo.py
+++ b/datamapper/repo.py
@@ -6,6 +6,7 @@ from typing_extensions import Protocol
 
 from datamapper._utils import assert_one, to_list, to_tree
 from datamapper.changeset import Changeset
+from datamapper.errors import InvalidChangesetError
 from datamapper.model import Association, Cardinality, Model
 from datamapper.query import Query
 
@@ -129,7 +130,7 @@ class Repo:
         """
         changeset = cast_changeset(model_or_changeset)
         if not changeset.is_valid:
-            return changeset
+            raise InvalidChangesetError(action="insert", changeset=changeset)
 
         model = changeset.data
         sql = model.__table__.insert().values(**changeset.changes)
@@ -147,7 +148,7 @@ class Repo:
             await repo.update(changeset)
         """
         if not changeset.is_valid:
-            return changeset
+            raise InvalidChangesetError(action="update", changeset=changeset)
 
         record = changeset.data
         query = record.to_query()


### PR DESCRIPTION
When attempting to insert or update a valid changeset, we'll raise an `InvalidChangesetError`.