### PR TITLE
Refactor changeset.py into a module

### DIFF
--- a/datamapper/changeset/__init__.py
+++ b/datamapper/changeset/__init__.py
@@ -1,0 +1,3 @@
+from .changeset import Changeset
+
+__all__ = ["Changeset"]

--- a/datamapper/changeset/data_wrapper.py
+++ b/datamapper/changeset/data_wrapper.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Generic, Optional, Tuple, Type
+
+from datamapper.changeset.types import Data
+from datamapper.changeset.utils import dict_merge
+from datamapper.model import Association, Model
+
+
+class ChangesetDataWrapper(Generic[Data]):
+    data: Data
+
+    def get(self, field: str, default: Any = None) -> Optional[Any]:
+        return self.attributes.get(field, default)
+
+    def apply_changes(self, changes: dict) -> Data:
+        raise NotImplementedError()  # pragma: no cover
+
+    def association(self, field: str) -> Association:
+        raise NotImplementedError()  # pragma: no cover
+
+    @property
+    def attributes(self) -> dict:
+        raise NotImplementedError()  # pragma: no cover
+
+    @property
+    def types(self) -> Dict[str, Type]:
+        raise NotImplementedError()  # pragma: no cover
+
+    def __repr__(self) -> str:
+        return self.data.__repr__()  # pragma: no cover
+
+
+class DictChangesetDataWrapper(ChangesetDataWrapper[dict]):
+    def __init__(self, data: Tuple[dict, dict]):
+        self.data: dict = data[0]
+        self._types: dict = data[1]
+
+    def apply_changes(self, changes: dict) -> dict:
+        return dict_merge(self.data, changes)
+
+    def association(self, field: str) -> Association:
+        raise ValueError("Data of type dict has no associations")
+
+    @property
+    def attributes(self) -> dict:
+        return self.data  # pragma: no cover
+
+    @property
+    def types(self) -> Dict[str, Type]:
+        return self._types
+
+
+class ModelChangesetDataWrapper(ChangesetDataWrapper[Model]):
+    def __init__(self, data: Model):
+        self.data: Model = data
+
+    def apply_changes(self, changes: dict) -> Model:
+        attrs = {**self.data.attributes, **changes}
+        return type(self.data)(**attrs)
+
+    def association(self, field: str) -> Association:
+        return self.data.association(field)
+
+    @property
+    def attributes(self) -> dict:
+        return self.data.attributes  # pragma: no cover
+
+    @property
+    def types(self) -> dict:
+        return {k: v.type for (k, v) in self.data.__table__.columns.items()}

--- a/datamapper/changeset/types.py
+++ b/datamapper/changeset/types.py
@@ -1,0 +1,6 @@
+from typing import Any, Callable, TypeVar, Union
+
+from datamapper.model import Model
+
+FieldValidator = Callable[[Any], Union[bool, str]]
+Data = TypeVar("Data", Model, dict)

--- a/datamapper/changeset/utils.py
+++ b/datamapper/changeset/utils.py
@@ -1,0 +1,5 @@
+def dict_merge(dct: dict, merge_dct: dict) -> dict:
+    dct_ = dict(dct)
+    for k, v in merge_dct.items():
+        dct_[k] = merge_dct[k]
+    return dct_

--- a/datamapper/changeset/validator.py
+++ b/datamapper/changeset/validator.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Type
+
+import sqlalchemy
+from marshmallow import Schema, ValidationError, fields
+
+from datamapper.changeset.types import FieldValidator
+
+
+class MarshmallowValidator:
+    def __init__(
+        self,
+        params: Dict[str, Any],
+        types: Dict[str, Any],
+        permitted: Set[str],
+        required: Set[str],
+        field_validators: Dict[str, List[FieldValidator]],
+    ):
+        self.params = params
+        self.types = types
+        self.permitted = permitted
+        self.required = required
+        self.field_validators = field_validators
+
+    @classmethod
+    def _to_marshmallow_field_type(cls, type_: Type) -> Type:
+        """
+        Maps types to marshmallow field types.
+        """
+        if isinstance(type_, sqlalchemy.String):
+            return fields.String
+        if isinstance(type_, sqlalchemy.BigInteger):
+            return fields.Integer
+        elif type_ in Schema.TYPE_MAPPING:
+            return Schema.TYPE_MAPPING[type_]
+        else:
+            return fields.Raw
+
+    def validate(self) -> Tuple[bool, dict]:
+        """
+        Programatically build a Marshmallow schema and validate against it.
+
+        Returns (True, changes) | (False, errors)
+        """
+        SchemaType = self._build_schema()
+        errors = SchemaType().validate(self.params)
+        if errors:
+            return (False, errors)
+
+        changes = SchemaType().dump(self.params)
+        return (True, changes)
+
+    def _build_schema(self) -> Type[Schema]:
+        """
+        Programatically build a Marshmallow Schema object.
+        """
+        all_fields = set(self.permitted).union(self.required)
+        field_definitions: Dict[str, fields.Field] = {
+            field: self._build_field(field) for field in all_fields
+        }
+        return Schema.from_dict(field_definitions)  # type: ignore
+
+    def _build_field(self, name: str) -> fields.Field:
+        """
+        Programatically build a Marshmallow Field object.
+
+        Attempts to map the sqlalchemy column type to the relevant field type.
+        """
+
+        def wrap_validator(validator: FieldValidator) -> Callable:
+            """
+            Turn a generic validation function into a marshmallow-flavored one that
+            raises a ValidationError with the message in question.
+            """
+
+            def _validate(val: Any) -> None:
+                result = validator(val)
+                if isinstance(result, str):
+                    raise ValidationError(result)
+
+            return _validate
+
+        field_type: Optional[Type] = self.types.get(name)
+        field_type = (
+            self._to_marshmallow_field_type(field_type)
+            if field_type is not None
+            else fields.Raw
+        )
+
+        type_args: Dict[str, Any] = {
+            "allow_none": True,
+            "required": name in self.required,
+        }
+
+        field_validators = self.field_validators.get(name)
+        if field_validators:
+            type_args["validate"] = [wrap_validator(v) for v in field_validators]
+
+        return field_type(**type_args)


### PR DESCRIPTION
`changeset.py` was getting a little crazy so I moved it into its own module.

In doing that I also reduced the coupling between the changeset and validator classes, which was giving me import headaches anyway.